### PR TITLE
Make it a bash script to fix job control on CI

### DIFF
--- a/run-experiment
+++ b/run-experiment
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # SPDX-License-Identifier: 0BSD
 # This script builds "sig" if necessary, runs the experiment, and cleans up.
 


### PR DESCRIPTION
Shell job control is mainly for interactive use, and shells vary in the situations where it is supported. In the noninteractive session on CI, the `set -m` command in the run-experiment script failed on Ubuntu, where `/bin/sh` is `dash`, but succeeded on macOS, where `/bin/sh` is (I think) `bash` 3.2. This change makes it work on both.

Besides its somewhat unusual use of job control, this script otherwise currently relies on no "bash-isms".

(SSHing in for tmate was never affected by this, but the main point of CI is noninteractive use, so I want that to work on both systems.)