### PR TITLE
Configure dev container; add more badges

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "sig (universal image)",
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bierner.markdown-preview-github-styles",
+                "eamodio.gitlens",
+                "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
+                "mads-hartmann.bash-ide-vscode",
+                "mhutchie.git-graph",
+                "ms-vscode.cpptools-extension-pack",
+                "timonwong.shellcheck"
+            ],
+            "settings": {
+                "gitlens.showWelcomeOnInstall": false,
+                "gitlens.showWhatsNewAfterUpgrades": false
+            }
+        }
+    },
+    "onCreateCommand": [".devcontainer/onCreate"]
+}

--- a/.devcontainer/git_prompt_activate.bash
+++ b/.devcontainer/git_prompt_activate.bash
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: 0BSD
+# This file, when sourced in ~/.bashrc, puts formatted __git_ps1 in $PS1.
+# Based on: https://github.com/EliahKagan/git_prompt_activate
+
+# shellcheck shell=bash
+# shellcheck disable=SC1091  # Not checking /usr/lib/git-core/git-sh-prompt.
+# shellcheck disable=SC2016  # PS1 will contain $ syntax for later expansion.
+# shellcheck disable=SC2034  # GIT_PS1_ vars will be assigned for later use.
+
+if test "$(git config devcontainers-theme.hide-status)" = 1 ||
+   test "$(git config codespaces-theme.hide-status)" = 1
+then
+    . /usr/lib/git-core/git-sh-prompt
+
+    git_prompt_part='$(__git_ps1 "(%s)")'
+
+    case "$TERM" in
+    xterm-color|*-256color)  # See color_prompt in .bashrc.
+        git_prompt_part='\[\033[36m\]'"$git_prompt_part"'\[\033[0m\]' ;;
+    esac
+
+    case "$PS1" in
+    *'\$ ')
+        PS1="${PS1/%\\$ /$git_prompt_part\\$ }" ;;
+    *)
+        PS1="${PS1/%$ /$git_prompt_part\\$ }" ;;
+    esac
+
+    unset git_prompt_part
+
+    GIT_PS1_SHOWDIRTYSTATE=1
+    GIT_PS1_SHOWSTASHSTATE=1
+    GIT_PS1_SHOWUNTRACKEDFILES=1
+    GIT_PS1_SHOWUPSTREAM=1
+fi

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,0 +1,10 @@
+#!/bin/sh
+# SPDX-License-Identifier: 0BSD
+
+set -eu
+
+# Customize git configuration for shell prompt.
+ln -s -- "$(realpath .devcontainer/git_prompt_activate.bash)" \
+    ~/.git_prompt_activate.bash
+printf '\n%s\n' '. ~/.git_prompt_activate.bash' >>~/.bashrc
+git config --global devcontainers-theme.hide-status 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- SPDX-License-Identifier: 0BSD -->
 
+[![GitHub license](https://img.shields.io/github/license/EliahKagan/sig)](https://github.com/EliahKagan/sig/blob/main/LICENSE)
 [![Run experiment](https://github.com/EliahKagan/sig/actions/workflows/main.yml/badge.svg)](https://github.com/EliahKagan/sig/actions/workflows/main.yml)
+[![Open in GitHub Codespaces](https://img.shields.io/badge/GitHub_Codespaces-Click_to_Open-blue)](https://codespaces.new/EliahKagan/sig)
 
 # sig - Unix signals demonstration
 


### PR DESCRIPTION
The reason to add badges is to add one that can be clicked to open a codespace, but I've also added a license badge while I was at it. (I did these together to make sure the colors look okay together.)