### PR TITLE
Just always have the parenthesized note on the step name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,22 @@ jobs:
   main:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+        manual:
+          - ${{ github.event_name == 'workflow_dispatch' }}
         include:
           - os: ubuntu-latest
             os-short: Ubuntu
           - os: macos-latest
             os-short: macOS
+          - manual: 'false'
+            tmate-note: ' (workflow_dispatch only)'
+          - manual: 'true'
+            tmate-note: ''
+
+    # name: main (${{ matrix.os }})
 
     continue-on-error: true
 
@@ -33,12 +43,7 @@ jobs:
       - name: Run experiment on ${{ matrix.os-short }}
         run: ./run-experiment
 
-      # FIXME: Build the name in a better way.
-      - name: |
-          ${{ format('Interact with {0} via tmate{1}',
-                     matrix.os-short,
-                     (github.event_name != 'workflow_dispatch' && ' (workflow_dispatch only)' || ''))
-          }}
+      - name: Interact with ${{ matrix.os-short }} via tmate${{ matrix.tmate-note }}
         if: (success() || failure()) && github.event_name == 'workflow_dispatch' && inputs.debug
         uses: mxschmitt/action-tmate@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,22 +15,12 @@ jobs:
   main:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        manual:
-          - ${{ github.event_name == 'workflow_dispatch' }}
+        os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
             os-short: Ubuntu
           - os: macos-latest
             os-short: macOS
-          - manual: 'false'
-            tmate-note: ' (workflow_dispatch only)'
-          - manual: 'true'
-            tmate-note: ''
-
-    # name: main (${{ matrix.os }})
 
     continue-on-error: true
 
@@ -43,7 +33,8 @@ jobs:
       - name: Run experiment on ${{ matrix.os-short }}
         run: ./run-experiment
 
-      - name: Interact with ${{ matrix.os-short }} via tmate${{ matrix.tmate-note }}
+      # FIXME: Build the name in a better way.
+      - name: Interact with ${{ matrix.os-short }} via tmate (workflow_dispatch only)
         if: (success() || failure()) && github.event_name == 'workflow_dispatch' && inputs.debug
         uses: mxschmitt/action-tmate@v3
         with:


### PR DESCRIPTION
The complex logic in the interpolated name was very bad, both in terms of the workflow's clarity and maintainability, and in that it used the brittle fake ternary conditional a && b || c. I had only introduced that a stopgap while trying to figure out a better way to express it. I didn't, and it's better not to have the feature that only provides the parenthesized note when needed, than to have it but write it this way.